### PR TITLE
support colon-aligned properties (fixes #1)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ const properties: { [key: string]: Property } = data;
 export function activate(context: vscode.ExtensionContext) {
 	const hoverProvider: vscode.HoverProvider = {
 		provideHover(doc, pos, token): vscode.ProviderResult<vscode.Hover> {
-			const range = doc.getWordRangeAtPosition(pos, /[a-z\-]+:/ig);
+			const range = doc.getWordRangeAtPosition(pos, /[a-z\-]+ *:/ig);
 
 			if (range === undefined) {
 				return;
@@ -51,7 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 function getInitialValue(word: string): string | string[] {
-	return properties[word.substring(0, word.length - 1)].initial;
+	return properties[word.slice(0, -1).trim()].initial;
 }
 
 function getText(initialValue: string | string[]): vscode.MarkdownString {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ const properties: { [key: string]: Property } = data;
 export function activate(context: vscode.ExtensionContext) {
 	const hoverProvider: vscode.HoverProvider = {
 		provideHover(doc, pos, token): vscode.ProviderResult<vscode.Hover> {
-			const range = doc.getWordRangeAtPosition(pos, /[a-z\-]+ *:/ig);
+			const range = doc.getWordRangeAtPosition(pos, /[a-z\-]+\s*:/ig);
 
 			if (range === undefined) {
 				return;


### PR DESCRIPTION
- tweaked regex to fix #1
- changed `substring` to `slice` which has simpler API (and IRRC is faster, but that doesn't really matter here) -- hopefully you don't mind :)

~~Haven't tested so I hope I didn't manage to mess something up with this trivial change.~~ EDIT: Manually tested, seems to work fine.

I see you don't have any tests set up, so I left this PR without it.