### PR TITLE
Add support for Vue and Svelte files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
 		"onLanguage:css",
 		"onLanguage:less",
 		"onLanguage:sass",
-		"onLanguage:scss"
+		"onLanguage:scss",
+		"onLanguage:vue",
+		"onLanguage:svelte"
 	],
 	"license": "MIT",
 	"main": "./out/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,23 @@ const properties: { [key: string]: Property } = data;
 export function activate(context: vscode.ExtensionContext) {
 	const hoverProvider: vscode.HoverProvider = {
 		provideHover(doc, pos, token): vscode.ProviderResult<vscode.Hover> {
+			const templateLanguages: string [] = ['vue', 'svelte'];
+			
+			if (templateLanguages.indexOf(doc.languageId) !== -1) {
+				const styleRegex = /<\s*style[^>]*>([\s\S]*?)<\s*\/\s*style>/g,
+						match = styleRegex.exec(doc.getText());
+	
+				if (match) {
+					const styleStartPos = doc.positionAt(match.index),
+						  styleEndPos = doc.positionAt(match.index + match[0].length),
+						  shouldShowInitialValue = (pos.line > styleStartPos.line && pos.line < styleEndPos.line);
+					
+					if (!shouldShowInitialValue) {
+						return;
+					}
+				}
+			}
+
 			const range = doc.getWordRangeAtPosition(pos, /[a-z\-]+\s*:/ig);
 
 			if (range === undefined) {
@@ -38,7 +55,7 @@ export function activate(context: vscode.ExtensionContext) {
 	};
 
 	let disposable = vscode.languages.registerHoverProvider(
-		['css', 'less', 'sass', 'scss'],
+		['css', 'less', 'sass', 'scss', 'vue', 'svelte'],
 		hoverProvider
 	);
 


### PR DESCRIPTION
Potentially closes #3 .

I'm not completely certain `templateLanguages` should be where it is right now, but if you want it somewhere else I can move it easily.

I'm using a regex that only matches the code encased in the `<style>` tags. This takes into account various Vue-esque attributes like `lang` and such (You can test it [here](https://regex101.com/r/hxN8hZ/1/)), then `TextDocument.positionAt` to determine which lines the start and end indexes of the match are located on, and from there I simply check if the line you're hovering is between the start and the end of the `<style>` tag, and if it is, the usual initial value code is ran.

I've only tested this briefly and on Vue files (I don't know Svelte), so I hope that it works in all scenarios. :)